### PR TITLE
fix(grouping): 修复对话分组新消息跨组窜入与未读已读残留问题，更新至 v227

### DIFF
--- a/app/src/main/java/com/Johnny/wcx/features/items/chat/ConversationGrouping.kt
+++ b/app/src/main/java/com/Johnny/wcx/features/items/chat/ConversationGrouping.kt
@@ -135,6 +135,9 @@ object ConversationGrouping : ClickableFeature(), IResolveDex {
     @Volatile
     private var activePredicate: String? = null
 
+    @Volatile
+    private var activeGroup: ChatGroup? = null
+
     private val groupsFile by lazy { KnownPaths.moduleData / "conversation_groups.json" }
 
     @Volatile
@@ -148,6 +151,7 @@ object ConversationGrouping : ClickableFeature(), IResolveDex {
 
     override fun onEnable() {
         hookConversationListQuery()
+        hookNewMessageNotification()
 
         methodOnTabCreate.hookAfter {
             val convListView = thisObject.reflekt()
@@ -231,8 +235,9 @@ object ConversationGrouping : ClickableFeature(), IResolveDex {
     }
 
     override fun onDisable() {
-        // Clear the active predicate so the conversation list shows all conversations.
+        // Clear the active predicate and group so the conversation list shows all conversations.
         activePredicate = null
+        activeGroup = null
         // Remove the tab bar header view from the ListView to clean up the UI.
         // Must run on the UI thread since it manipulates the View hierarchy.
         runOnUiThread {
@@ -357,6 +362,7 @@ object ConversationGrouping : ClickableFeature(), IResolveDex {
         // groups need a DB read to materialize their member list, and doing that while WeChat is
         // already running the list query would nest reads on the same path.
         // The "全部" tab (or a null group) applies no filter.
+        activeGroup = if (group == null || isAllTab(group.id)) null else group
         activePredicate = if (group == null || isAllTab(group.id)) {
             null
         } else {
@@ -404,6 +410,64 @@ object ConversationGrouping : ClickableFeature(), IResolveDex {
             val sql = args.firstOrNull() as? String ?: return@hookBefore
             rewriteConversationListSql(sql)?.let { args[0] = it }
         }
+    }
+
+    // Hooks the ConversationStorage notify dispatcher to handle real-time per-row update events (type 3).
+    // 1. In custom / preset groups: prevents new messages of non-member talkers from popping up in the active tab.
+    // 2. In PRESET_UNREAD: when an open chat is read (unread becomes 0), automatically triggers reload to remove it from unread tab.
+    private fun hookNewMessageNotification() {
+        val method = WeConversationApi.methodNotifyConversationChanged
+        if (method.isPlaceholder) {
+            WeLogger.w(TAG, "conversation notify method not resolved; tab message filtering unavailable")
+            return
+        }
+        method.hookBefore {
+            val eventType = args[0] as? Int ?: return@hookBefore
+            if (eventType != 3) return@hookBefore
+            val talker = args[2] as? String ?: return@hookBefore
+            if (talker.isEmpty()) return@hookBefore
+
+            val currentGroup = activeGroup ?: return@hookBefore
+
+            if (currentGroup.type == GroupType.PRESET_UNREAD) {
+                if (!isConversationUnread(talker)) {
+                    result = null
+                    WeConversationApi.reloadConversations()
+                    return@hookBefore
+                }
+                return@hookBefore
+            }
+
+            if (!isTalkerInActiveGroup(talker, currentGroup)) {
+                result = null
+            }
+        }
+    }
+
+    private fun isTalkerInActiveGroup(talker: String, group: ChatGroup): Boolean {
+        return when (group.type) {
+            GroupType.MANUAL -> group.members.contains(talker)
+            GroupType.PRESET_GROUPS -> talker.endsWith("@chatroom")
+            GroupType.PRESET_OFFICIALS -> talker.startsWith("gh_")
+            GroupType.PRESET_UNREAD -> isConversationUnread(talker)
+            GroupType.SQL -> getGroupMembers(group).contains(talker)
+        }
+    }
+
+    private fun isConversationUnread(talker: String): Boolean {
+        return runCatching {
+            val cursor = WeDatabaseApi.rawQuery(
+                "SELECT unReadCount, unReadMuteCount FROM rconversation WHERE username = ? LIMIT 1",
+                arrayOf(talker)
+            )
+            cursor.use { c ->
+                if (c.moveToFirst()) {
+                    val unread = c.getInt(0)
+                    val unreadMute = c.getInt(1)
+                    unread > 0 || unreadMute > 0
+                } else false
+            }
+        }.getOrDefault(false)
     }
 
     // Returns the rewritten SQL, or null to leave it untouched (all non-list queries and "全部").

--- a/app/src/main/java/com/Johnny/wcx/features/items/system/RecentUpdates.kt
+++ b/app/src/main/java/com/Johnny/wcx/features/items/system/RecentUpdates.kt
@@ -19,6 +19,11 @@ data class RecentUpdateItem(
  */
 val RECENT_UPDATES = listOf(
     RecentUpdateItem(
+        name = "对话分组多场景过滤体验修复",
+        description = "彻底修复停留在特定分组时新消息跨组窜入的问题，以及未读分组中会话读完返回后已读消息自动消失",
+        featureKey = "对话分组"
+    ),
+    RecentUpdateItem(
         name = "禁止主页下滑进入最近页面",
         description = "禁止主页下滑手势，同时支持通过加号菜单和标题栏图标唤起微信原生小程序面板",
         featureKey = "禁止主页下滑进入最近页面"


### PR DESCRIPTION
## 描述 / Description
本次 PR 针对对话分组（ConversationGrouping）功能修复了两项影响日常体验的实时刷新问题：

1. **修复新消息跨组窜入问题**：
   - **问题现象**：停留在特定自定义分组（或群聊/公众号分组）时，如果收到不属于该分组的新消息，该会话会被微信增量通知机制直接插入当前列表顶部。
   - **修复方案**：通过 Hook `WeConversationApi.methodNotifyConversationChanged`（单条变更通知事件 `eventType == 3`），在处于非“全部”Tab 时对非本组成员的会话更新通知进行拦截（`result = null`），阻止非本组会话插入屏幕。

2. **修复未读分组已读会话残留问题**：
   - **问题现象**：在“未读”分组中进入某会话读完消息返回后，已读会话依然停留在未读列表中，需切换 Tab 才能刷新。
   - **修复方案**：在通知拦截中增加对 `PRESET_UNREAD` 的状态感知，检测到会话未读数归零时，自动在主线程触发轻量重新查询（`reloadConversations()`），使已读会话立即平滑消失。

3. **版本与配置适配**：
   - 更新近期功能说明列表；
   - 优化本地构建与环境配置。

## 类型 / Type
- [x] Bug 修复
- [ ] 新功能
- [x] 文档更新
- [ ] 其他

## 清单 / Checklist
- [x] 我已阅读并遵循贡献指南
- [x] 我已在本地测试这些更改
- [x] 我已更新相关文档或注释
- [x] 我确认此更改不会破坏任何原有功能
- [x] 我已在多个微信版本上测试此更改

### 合规性与原创性声明 / Compliance & Originality
- [x] **如果参考了其他开源项目，我已在"其他信息"中明确标注来源及协议**

## 其他信息 / Additional Information
- 拦截仅针对前端 ListView 增量刷新的事件分发，微信后台数据库（`rconversation` 与 `message`）完整正常保存，消息与红点零丢失；
- 切换至“全部”Tab 或其他分组时，通过原有 SQL 聚合查询呈现完整状态；
- 已在本地完成编译验证与微信实机测试，运行平稳顺畅。