### PR TITLE
fix(chat): 修复修改文本消息显示后再次点击/长按崩溃的问题

### DIFF
--- a/app/src/main/java/com/Johnny/wcx/features/items/chat/ModifyTextMessageDisplay.kt
+++ b/app/src/main/java/com/Johnny/wcx/features/items/chat/ModifyTextMessageDisplay.kt
@@ -1,5 +1,7 @@
 package com.Johnny.wcx.features.items.chat
 
+import android.text.SpannableString
+import android.text.SpannableStringBuilder
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.getValue
@@ -17,17 +19,87 @@ import com.Johnny.wcx.ui.content.TextButton
 import com.Johnny.wcx.ui.utils.EditIcon
 import com.Johnny.wcx.ui.utils.showComposeDialog
 
-@Feature(name = "修改文本消息显示", categories = ["聊天"], description = "向消息长按菜单添加菜单项, 可修改本地消息显示内容")
+@Feature(name = "修改文本消息显示", categories = ["聊天"], description = "向消息长按菜单添加菜单项, 可修改本地消息显示内容（纯内存临时修改，重启微信自动恢复）")
 object ModifyTextMessageDisplay : SwitchFeature(),
     WeChatMessageContextMenuApi.IMenuItemsProvider {
 
     override fun onEnable() {
         WeChatMessageContextMenuApi.addProvider(this)
+
+        installSpannableBoundsProtection()
     }
 
     override fun onDisable() {
         WeChatMessageContextMenuApi.removeProvider(this)
     }
+
+    private fun installSpannableBoundsProtection() {
+        val targetClasses = listOfNotNull(
+            SpannableString::class.java,
+            SpannableStringBuilder::class.java,
+            runCatching { Class.forName("android.text.SpannableStringInternal") }.getOrNull()
+        )
+
+        for (clazz in targetClasses) {
+            // 1. 保护 setSpan(Object what, int start, int end, int flags)
+            runCatching {
+                clazz.reflekt()
+                    .firstMethodOrNull { name = "setSpan"; parameters(Any::class, Int::class, Int::class, Int::class) }
+                    ?.hookBefore {
+                        val ss = thisObject as? CharSequence ?: return@hookBefore
+                        val len = ss.length
+                        var start = args[1] as Int
+                        var end = args[2] as Int
+                        if (start < 0) start = 0
+                        if (start > len) start = len
+                        if (end < 0) end = 0
+                        if (end > len) end = len
+                        if (start > end) start = end
+                        args[1] = start
+                        args[2] = end
+                    }
+            }
+
+            // 2. 保护 subSequence(int start, int end)
+            runCatching {
+                clazz.reflekt()
+                    .firstMethodOrNull { name = "subSequence"; parameters(Int::class, Int::class) }
+                    ?.hookBefore {
+                        val ss = thisObject as? CharSequence ?: return@hookBefore
+                        val len = ss.length
+                        var start = args[0] as Int
+                        var end = args[1] as Int
+                        if (start < 0) start = 0
+                        if (start > len) start = len
+                        if (end < 0) end = 0
+                        if (end > len) end = len
+                        if (start > end) start = end
+                        args[0] = start
+                        args[1] = end
+                    }
+            }
+
+            // 3. 保护 checkRange(String operation, int start, int end)
+            runCatching {
+                clazz.reflekt()
+                    .firstMethodOrNull { name = "checkRange"; parameters(String::class, Int::class, Int::class) }
+                    ?.hookBefore {
+                        val ss = thisObject as? CharSequence ?: return@hookBefore
+                        val len = ss.length
+                        var start = args[1] as Int
+                        var end = args[2] as Int
+                        if (start < 0) start = 0
+                        if (start > len) start = len
+                        if (end < 0) end = 0
+                        if (end > len) end = len
+                        if (start > end) start = end
+                        args[1] = start
+                        args[2] = end
+                    }
+            }
+        }
+    }
+
 
     override fun getMenuItems(): List<WeChatMessageContextMenuApi.MenuItem> {
         return listOf(
@@ -39,15 +111,17 @@ object ModifyTextMessageDisplay : SwitchFeature(),
                 { msgInfo -> msgInfo.type?.isText ?: false },
                 // operates on the single message's own View; can't apply to a batch
                 multiSelect = WeChatMessageContextMenuApi.MultiSelectSupport.Unsupported
-            ) { view, _, _ ->
+            ) { view, _, msgInfo ->
                 showComposeDialog(view.context) {
                     var input by remember {
                         mutableStateOf(
-                            view.reflekt()
-                                .firstField {
-                                    type = CharSequence::class
-                                    superclass()
-                                }.get().toString()
+                            msgInfo.actualContent.ifEmpty {
+                                view.reflekt()
+                                    .firstField {
+                                        type = CharSequence::class
+                                        superclass()
+                                    }.get().toString()
+                            }
                         )
                     }
 
@@ -61,11 +135,27 @@ object ModifyTextMessageDisplay : SwitchFeature(),
                         },
                         confirmButton = {
                             TextButton(onClick = {
-                                view.reflekt()
-                                    .firstMethod {
-                                        parameters(CharSequence::class)
-                                    }
-                                    .invoke(input)
+                                // 1. 同步更新内存中的 MsgInfo 实体，确保长按选区控制器获取一致的文本长度
+                                val fullContent = if (msgInfo.isInGroupChat && msgInfo.isSend == 0 && msgInfo.content.contains(":\n")) {
+                                    val prefix = msgInfo.content.substringBefore(":\n") + ":\n"
+                                    prefix + input
+                                } else {
+                                    input
+                                }
+
+                                runCatching {
+                                    msgInfo.instance.reflekt().firstFieldOrNull { name = "field_content" }?.set(fullContent)
+                                    msgInfo.instance.reflekt().firstMethodOrNull { name = "setContent"; parameters(String::class) }?.invoke(fullContent)
+                                }
+
+                                // 2. 更新 View 文本显示并刷新布局
+                                runCatching {
+                                    view.reflekt().firstMethodOrNull { name = "setText"; parameters(CharSequence::class) }?.invoke(input)
+                                        ?: view.reflekt().firstMethod { parameters(CharSequence::class) }.invoke(input)
+                                }
+                                view.requestLayout()
+                                view.invalidate()
+
                                 onDismiss()
                             }) {
                                 Text("确定")
@@ -81,3 +171,4 @@ object ModifyTextMessageDisplay : SwitchFeature(),
         )
     }
 }
+


### PR DESCRIPTION
### 🛠️ 问题背景 (Problem)

使用「修改文本消息显示」功能将一条原本较长的消息（如 5 个字符）修改为较短的内容（如 4 个字符）后，在聊天界面**再次点击或长按该消息**时会导致微信主线程闪退崩溃。

**崩溃堆栈：**
1. `java.lang.StringIndexOutOfBoundsException: begin 0, end 5, length 4 at android.text.SpannableString.subSequence(...)`
2. `java.lang.IndexOutOfBoundsException: setSpan (0 ... 5) ends beyond length 4 at android.text.SpannableStringInternal.checkRange(...)`

**根因定位：**
1. 原实现仅反射调用了 `view.setText(input)`，未同步微信内存中 `MsgInfo` 对象（`field_content` / `setContent`），导致微信长按文本选择器与闭包依然保留着旧文本长度（5 字符）的选区范围 `[0, 5]`；
2. 长按事件触发时，微信尝试对 4 字符的实际视图进行 `subSequence(0, 5)` 及 `setSpan(span, 0, 5)` 高亮操作，由于 `end > length` 直接引发越界异常。

---

### 💡 解决方案 (Solution)

1. **内存级数据同步**：
   - 用户确认修改时，同步更新内存中 `MsgInfo` 实体的 `field_content` 字段与 `setContent` 方法，使内存实体与屏幕 View 的文本长度保持完全一致；
   - 保持纯内存修改特性，不写入 SQLite 数据库（重启微信或退出重进即可自动恢复原生原内容）；
2. **群聊发送者协议头兼容**：
   - 群聊中非本人发送的消息自动保留 `wxid_xxx:\n` 协议前缀，防止修改后群头像与发送者解析错乱；
3. **全链路 Spannable 边界自适应防护 (`installSpannableBoundsProtection`)**：
   - 针对 `SpannableString`、`SpannableStringBuilder` 及 `SpannableStringInternal` 的以下方法增加了前置边界安全夹紧防护（`0 <= start <= end <= len`）：
     - `setSpan(what, start, end, flags)`：防止长按选中高亮时因旧闭包长度大于新文本长度引发越界；
     - `subSequence(start, end)`：防止选区截取越界；
     - `checkRange(operation, start, end)`：拦截系统底层的区间越界检测。

---

### 🧪 验证与测试 (Verification)

- [x] 在聊天界面将 10+ 字符文本修改为 2 个字符后，多次点击、长按该消息，弹出菜单及选中文本高亮正常，无任何闪退崩溃；
- [x] 杀掉微信进程重新进入聊天，消息自动恢复为原始文本，数据库无损；
- [x] 成功通过 Release 编译构建并在 Android 15 / 微信 8.0.74 环境下实机验证通过。
